### PR TITLE
Fixed a bug with an incorrect type for "keep" operation of "data" command.

### DIFF
--- a/WorldEditCommands/data/DataParameters.cs
+++ b/WorldEditCommands/data/DataParameters.cs
@@ -11,7 +11,7 @@ public class DataParameters() : BaseParameters(SupportedOperations)
     ["merge"] = typeof(string[]),
     ["set"] = typeof(string[]),
     ["remove"] = typeof(string[]),
-    ["keep"] = typeof(string),
+    ["keep"] = typeof(string[]),
     ["print"] = typeof(bool),
     ["copy_raw"] = typeof(string),
 


### PR DESCRIPTION
When i tested "data clear", i needed to exclude remove of some values. I saw that "data keep=key1,key2" was throwing an error instead of correctly processing the specified keys.